### PR TITLE
Added support for Apple's UIPrinterPickerController

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The plugin creates the object `cordova.plugins.printer` with the following metho
 
 1. [printer.isAvailable][available]
 2. [printer.print][print]
+3. [printer.print][printerPicker] (iOS only)
 
 ### Plugin initialization
 The plugin and its methods are not available before the *deviceready* event has been fired.
@@ -247,6 +248,40 @@ cordova.plugins.printer.print('123', { bounds:[40, 30, 0, 0] });
 cordova.plugins.printer.print('123', { bounds:{ left:40, top:30, width:0 height:0 } });
 ```
 
+### Display printer picker (iOS 8.0+ only)
+Displays a system interface allowing the user to select an available printer.  The callback function will return the network URL of the selected printer (null if no printer selected).  The URL can be passed into the print function (printerId option), allowing a page to be printed without prompting the user.  This feature is only available in iOS 8.0 and later.
+
+#### Available Options
+| Name | Description | Type | Support |
+| ---- | ----------- |:----:| -------:|
+| bounds | The Size and position of the printer picker view | Array | iPad |
+
+#### Examples
+
+##### 1. Display the picker
+```javascript
+cordova.plugins.printer.printerPicker(function (printerId) {
+    alert(printerId)
+});
+```
+
+##### 2. Display picker at particular point on the screen and print current page to the selected printer
+```javascript
+cordova.plugins.printer.printerPicker(function (printerId) {
+    if(printerId)
+    {
+        // URI for the index.html
+        var page = location.href;
+        cordova.plugins.printer.print(page, {name: 'Document.html', printerId: printerId }, function () {
+            alert('Printing finished?')
+        });
+    }
+    else
+    {
+        alert('Printer not selected');
+    }
+}, { bounds: { left:100, top:300, width:0, height: 0 } } );
+```
 
 ## Quirks
 

--- a/src/ios/APPPrinter.h
+++ b/src/ios/APPPrinter.h
@@ -29,5 +29,7 @@
 - (void) print:(CDVInvokedUrlCommand*)command;
 // Find out whether printing is supported on this platform
 - (void) isAvailable:(CDVInvokedUrlCommand*)command;
+// Displays system interface for selecting a printer
+- (void) printerPicker:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/www/printer.js
+++ b/www/printer.js
@@ -58,6 +58,21 @@ exports.isAvailable = function (callback, scope) {
 };
 
 /**
+ * Displays system interface for selecting a printer (iOS only)
+ *
+ * @param {Function} callback
+ *      A callback function
+ * @param {Object} options
+ *       Options for the printer picker
+ */
+exports.printerPicker = function (callback, options) {
+    var fn = this._createCallbackFn(callback);
+    var params = options || {};
+    params = this.mergeWithDefaults(params);
+    exec(fn, null, 'Printer', 'printerPicker', [params]);
+};
+
+/**
  * Sends the content to the Google Cloud Print service.
  *
  * @param {String} content


### PR DESCRIPTION
I have a use case where an app is used in a kiosk mode.  An admin needs to be able to configure what printer the iPad prints to, but the user would not be able to change the printer or number of copies.

I added an additional function (printerPicker) to your great plugin that exposes Apple's UIPrinterPickerController, which allows the printer to be selected separate from the print dialogue.

I updated the readme to include documentation for the new function.