### PR TITLE
Remove CDV_IsIPad

### DIFF
--- a/src/ios/APPPrinter.m
+++ b/src/ios/APPPrinter.m
@@ -195,7 +195,7 @@
 - (void) presentPrintController:(UIPrintInteractionController*)controller
                        fromRect:(CGRect)rect
 {
-    if(CDV_IsIPad()) {
+    if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
         [controller presentFromRect:rect inView:self.webView animated:YES completionHandler:
          ^(UIPrintInteractionController *ctrl, BOOL ok, NSError *e) {
              CDVPluginResult* pluginResult =


### PR DESCRIPTION
Remove CDV_IsIPad since it has been deprecated by Cordova, and replacing it with: [[ UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ]].