### PR TITLE
Cache UIPrinter

### DIFF
--- a/src/ios/APPPrinter.h
+++ b/src/ios/APPPrinter.h
@@ -25,6 +25,9 @@
 
 @interface APPPrinter : CDVPlugin <UIWebViewDelegate>
 
+// this is used to cache the uiprinter making repeated prints faster
+@property (nonatomic) UIPrinter *previousPrinter;
+
 // Find out whether printing is supported on this platform
 - (void) check:(CDVInvokedUrlCommand*)command;
 // Displays system interface for selecting a printer

--- a/src/ios/APPPrinter.m
+++ b/src/ios/APPPrinter.m
@@ -195,8 +195,15 @@
                printer:(NSString*)printerId
 {
     NSURL* url         = [NSURL URLWithString:printerId];
-    UIPrinter* printer = [UIPrinter printerWithURL:url];
-
+    
+    // check to see if we have previously created this printer to reduce printing/"contacting" time
+    if(self.previousPrinter == nil || [[self.previousPrinter URL] absoluteString] != printerId) {
+        self.previousPrinter = [UIPrinter printerWithURL:url];
+    }
+    
+    UIPrinter* printer = self.previousPrinter;
+    
+    
     [controller printToPrinter:printer completionHandler:
      ^(UIPrintInteractionController *ctrl, BOOL ok, NSError *e) {
          CDVPluginResult* pluginResult =

--- a/src/ios/APPPrinter.m
+++ b/src/ios/APPPrinter.m
@@ -197,7 +197,7 @@
     NSURL* url         = [NSURL URLWithString:printerId];
     
     // check to see if we have previously created this printer to reduce printing/"contacting" time
-    if(self.previousPrinter == nil || [[self.previousPrinter URL] absoluteString] != printerId) {
+    if(self.previousPrinter == nil || ![[[self.previousPrinter URL] absoluteString] isEqualToString: printerId]) {
         self.previousPrinter = [UIPrinter printerWithURL:url];
     }
     


### PR DESCRIPTION
We do lots of printing through our app and noticed the contacting time was very severe. If you cache the UIPrinter instance this speeds up significantly.

Let me know your thoughts. Thanks for this (and many other) Cordova plugins

In our usage this speeds up printing time from 25 seconds to < 5