### PR TITLE
Added optional support for javascript to the WebView

### DIFF
--- a/src/android/Printer.java
+++ b/src/android/Printer.java
@@ -218,11 +218,15 @@ public class Printer extends CordovaPlugin {
         Activity ctx         = cordova.getActivity();
         view                 = new WebView(ctx);
         WebSettings settings = view.getSettings();
+        final boolean jsEnabled = props.optBoolean("javascript", false);
 
         settings.setDatabaseEnabled(true);
         settings.setGeolocationEnabled(true);
         settings.setSaveFormData(true);
         settings.setUseWideViewPort(true);
+        if (jsEnabled) {
+            settings.setJavaScriptEnabled(jsEnabled);
+        }
         view.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
 
         if (Build.VERSION.SDK_INT >= 21) {


### PR DESCRIPTION
I have a page that needs to use JavaScript.  Android WebView has javascript disabled by default:
https://developer.android.com/reference/android/webkit/WebSettings.html#setJavaScriptEnabled(boolean)

This PR lets the user pass an option that will enable it.  Default is for javascript to remain disabled for backwards compatibility.