### PR TITLE
I fixed the app crashing exception for Android after pressing 'back' …

### DIFF
--- a/src/android/Printer.java
+++ b/src/android/Printer.java
@@ -343,14 +343,16 @@ public class Printer extends CordovaPlugin {
      */
     @Override
     public void onDestroy() {
-        pm.unsetOnPrintJobStateChangeListener();
+ 	if(pm != null && listener != null && command != null && view != null) {
+       	   pm.unsetOnPrintJobStateChangeListener();
 
-        pm       = null;
-        listener = null;
-        command  = null;
-        view     = null;
+       	   pm       = null;
+           listener = null;
+           command  = null;
+           view     = null;
 
-        super.onDestroy();
+           super.onDestroy();
+	}
     }
 
     /**


### PR DESCRIPTION
Why this fix is required?
Once the print window is open using this plugin and if user press 'Back' key multiple times, the app got crashed. After going though 'printer.java' class, I found the onDestroy() is called multiple times when pressing 'back' key which was causing the problem. Therefore, I added a check (if condition)  to check if the respective listeners are not null. It fixed the problem and the app does not crash anymore. :)