### PR TITLE
Configuring mergeWithDefaults Method to Return Defaults

### DIFF
--- a/www/printer.js
+++ b/www/printer.js
@@ -135,6 +135,10 @@ exports.print = function (content, options, callback, scope) {
 exports.mergeWithDefaults = function (options) {
     var defaults = this.getDefaults();
 
+    if( options === undefined ){
+        return this.getDefaults();
+    }
+    
     if (options.bounds && !options.bounds.length) {
         options.bounds = [
             options.bounds.left   || defaults.bounds[0],


### PR DESCRIPTION
When calling the printer.pick method, the APPPrinter.m class method fails since options are expected, but none are passed.

```
    NSMutableDictionary* settings = [arguments objectAtIndex:0];
    NSArray* bounds = [settings objectForKey:@"bounds"];
```

(the settings are "null" here).

The decorator associated with the typescript resource for the plugin doesn't allow options to be provided and, subsequently, the option merge returns undefined for the params:

`params = this.mergeWithDefaults(params);
`

I've implemented a workaround so that the plugin.js "mergeWithDefaults" returns the defaults when none are passed or an empty object when an empty object is passed in, but this seems like a hack.