### PR TITLE
Windows crash fix

### DIFF
--- a/src/windows/PrinterProxy.js
+++ b/src/windows/PrinterProxy.js
@@ -114,7 +114,11 @@ exports.onPrintTaskRequested = function (event) {
         task.options.duplex = Printing.PrintDuplex.oneSided;
     }
 
-    task.options.numberOfCopies = config.copies || 1;
+    // handling exception to prevent app to crash
+    try {        
+		task.options.numberOfCopies = 1;
+    } catch (e) {
+    }
 
     task.oncompleted = function (e) {
         exports._func(e.detail[0].completion == 3);

--- a/src/windows/PrinterProxy.js
+++ b/src/windows/PrinterProxy.js
@@ -116,7 +116,7 @@ exports.onPrintTaskRequested = function (event) {
 
     // handling exception to prevent app to crash
     try {        
-		task.options.numberOfCopies = 1;
+		task.options.numberOfCopies = config.copies || 1;
     } catch (e) {
     }
 


### PR DESCRIPTION
In windows platform, an app will crash if nuberOfCopies property will be specified.
This is known issure in UWP and propably in future will be solved.
So to fix this in meantime, suggesting to wrap that line with try catch block.