### PR TITLE
Support for roll printers

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ The method accepts a list of attributes. Not all are supported on each platform 
 | hidePageRange | Set to _true_ to hide the control for the page range.<br>Defaults to: false | Boolean | iOS |
 | hideNumberOfCopies | Set to _true_ to hide the control for the number of copies.<br>Defaults to: false | Boolean | iOS |
 | hidePaperFormat | Set to _true_ to hide the control for the paper format.<br>Defaults to: false | Boolean | iOS |
+| paperWidth | Ability to hint width of the paper – iOS will get a printer supported paperformat which fits the best to this width. Only works when `paperHeight` is given. Width in millimeters. | Number | iOS |
+| paperHeight | Ability to hint height of the paper – iOS will get a printer paperformat which fits the best to this heigth. Only works when `paperWidth` is given. Height in millimeters. | Number | iOS |
+| paperCutLength | On roll-fed printers you can decide after how many milimeters the printer cuts the paper. | Number | iOS |
 | bounds | The Size and position of the print view<br>Defaults to: [40, 30, 0, 0] | Array | iPad |
 
 #### Further informations

--- a/src/ios/APPPrinter.h
+++ b/src/ios/APPPrinter.h
@@ -23,7 +23,7 @@
 #import <Cordova/CDVPlugin.h>
 
 
-@interface APPPrinter : CDVPlugin <UIWebViewDelegate>
+@interface APPPrinter : CDVPlugin <UIWebViewDelegate, UIPrintInteractionControllerDelegate>
 
 // this is used to cache the uiprinter making repeated prints faster
 @property (nonatomic) UIPrinter *previousPrinter;

--- a/src/ios/APPPrinter.m
+++ b/src/ios/APPPrinter.m
@@ -76,6 +76,7 @@
     self.settings                 = [arguments objectAtIndex:1];
 
     UIPrintInteractionController* controller = [self printController];
+    controller.delegate = self;
 
     [self adjustPrintController:controller withSettings:self.settings];
     [self loadContent:content intoPrintController:controller];
@@ -333,6 +334,42 @@
 }
 
 /**
+ * Choose paper Delegate. If Paper-Size is given it selects the best fitting papersize
+ */
+
+- (UIPrintPaper *) printInteractionController:(UIPrintInteractionController *)printInteractionController choosePaper:(NSArray *)paperList {
+    if ([[self.settings objectForKey:@"paperHeight"] doubleValue] && [[self.settings objectForKey:@"paperHeight"] doubleValue]){
+        double heigth = [[self.settings objectForKey:@"paperHeight"] doubleValue];
+        double width = [[self.settings objectForKey:@"paperWidth"] doubleValue];
+        double dotsHeigth = 72*heigth / 25.4; //convert milimeters to dots
+        double dotsWidth = 72*width / 25.4; //convert milimeters to dots
+        CGSize pageSize = CGSizeMake(dotsHeigth, dotsWidth);
+        
+        // get best fitting paper size
+        UIPrintPaper* paper = [UIPrintPaper bestPaperForPageSize:pageSize withPapersFromArray:paperList];
+        return paper;
+    }
+    else {
+        return NULL;
+    }
+}
+
+/**
+ * cutPaper Delegate. If using roll printers like Label-Printer (brother QL-710W) you can cut paper after given length.
+ */
+- (CGFloat)printInteractionController:(UIPrintInteractionController *)printInteractionController
+                    cutLengthForPaper:(UIPrintPaper *)paper {
+    if ([[self.settings objectForKey:@"paperCutLength"] doubleValue]){
+        NSLog(@"Paper Cut size size %f,%f",paper.paperSize.width, paper.paperSize.height);
+        double cutLength = [[self.settings objectForKey:@"paperCutLength"] doubleValue];
+        return 72 * cutLength / 25.4; //convert milimeters to dots
+    } else {
+        return paper.paperSize.height;
+    }
+}
+
+
+/**
  * Loads the content into the print controller.
  *
  * @param {NSString} content
@@ -385,3 +422,4 @@
 }
 
 @end
+ 

--- a/src/ios/APPPrinter.m
+++ b/src/ios/APPPrinter.m
@@ -99,9 +99,13 @@
     NSArray*  arguments           = [command arguments];
     NSMutableDictionary* settings = [arguments objectAtIndex:0];
 
-    NSArray* bounds = [settings objectForKey:@"bounds"];
-    CGRect rect     = [self convertIntoRect:bounds];
 
+    CGRect rect     = CGRectMake(40, 30, 0, 0); //Default in documentation
+    if (settings != (id)[NSNull null] && [settings objectForKey:@"bounds"] != nil){
+        NSArray* bounds = [settings objectForKey:@"bounds"];
+        rect     = [self convertIntoRect:bounds];
+    }
+    
     [self presentPrinterPicker:rect];
 }
 

--- a/src/ios/APPPrinter.m
+++ b/src/ios/APPPrinter.m
@@ -364,7 +364,6 @@
 - (CGFloat)printInteractionController:(UIPrintInteractionController *)printInteractionController
                     cutLengthForPaper:(UIPrintPaper *)paper {
     if ([[self.settings objectForKey:@"paperCutLength"] doubleValue]){
-        NSLog(@"Paper Cut size size %f,%f",paper.paperSize.width, paper.paperSize.height);
         double cutLength = [[self.settings objectForKey:@"paperCutLength"] doubleValue];
         return 72 * cutLength / 25.4; //convert milimeters to dots
     } else {


### PR DESCRIPTION
Added support for roll printers / label printers. Tested with Brother QL-720W.
Can hint paper size and set cut length of paper on roll printers with endless paper.