### PR TITLE
Fix wrong value returned from cutLengthForPaper

### DIFF
--- a/src/ios/APPPrinter.m
+++ b/src/ios/APPPrinter.m
@@ -121,7 +121,7 @@
     APPPrinterPaper* paperSpec = [[APPPrinterPaper alloc]
                                   initWithDictionary:ctrl.settings[@"paper"]];
 
-    return paperSpec.length || paper.paperSize.height;
+    return (paperSpec.length)?paperSpec.length:paper.paperSize.height;
 }
 
 #pragma mark -


### PR DESCRIPTION
On Swift, || operator doesn't behave the same way as Javascript does. 

Because of this, this code always returned 1 

`return paperSpec.length || paper.paperSize.height `