### PR TITLE
[Windows] Support full margin syntax plus percentScale

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ The list of possible options depend on the platform, the content type and the ca
 | autoFit | Set to _false_ to disable downscaling the image to fit into the content aread. | Boolean | Android |
 | printer | The network URL to the printer. | String | iOS |
 | maxHeight<br>maxWidth | Defines the maximum size of the content area. | Unit | iOS |
+| percentScale | Defines a percentage to scale the content (0 - 100). | Number | Windows |
 | margin | Set to _false_ to avoid margins. | Boolean | all |
-| margin.top<br>margin.left<br>margin.right<br>margin.bottom | The margins for each printed page. Each printer might have its own minimum margins depends on media type and paper format. | Unit | iOS |
+| margin.top<br>margin.left<br>margin.right<br>margin.bottom | The margins for each printed page. Each printer might have its own minimum margins depends on media type and paper format. | Unit | iOS<br>Windows |
 | ui.hideNumberOfCopies | Set to _true_ to hide the control for the number of copies. | Boolean | iOS |
 | ui.hidePaperFormat | Set to _true_ to hide the control for the paper format. | Boolean | iOS |
 | ui.top<br>ui.left | The position of the printer picker. | Number | iPad |

--- a/src/windows/PrinterProxy.js
+++ b/src/windows/PrinterProxy.js
@@ -97,6 +97,7 @@ exports.print = function (success, fail, args)
     exports._args = args[1];
 
     MSApp.getHtmlPrintDocumentSourceAsync(page).then(function (source) {
+        configureHtmlPrintDocumentSource(source, args[1]);
         exports._page = source;
         PrintManager.showPrintUIAsync();
     });
@@ -154,11 +155,6 @@ exports.onPrintTaskRequested = function (event)
         spec.mediaType    = Printing.PrintMediaType.photographic;
     }
 
-    if (config.margin === false)
-    {
-        spec.bordering = Printing.PrintBordering.borderless;
-    }
-
     if (config.paper && config.paper.name)
     {
         spec.mediaSize = Printing.PrintMediaSize[config.paper.name] || Printing.PrintMediaSize.default;
@@ -172,6 +168,85 @@ exports.onPrintTaskRequested = function (event)
         exports._func(e.detail[0].completion === 3);
     };
 };
+
+function configureHtmlPrintDocumentSource(source, config) {
+    var margin = config.margin === false ? { top: 0, left: 0, bottom: 0, right: 0 } : config.margin;
+
+    if (margin) {
+        // By observation, the units expected for these margin properties are hundredths of an
+        // inch. Unfortunately, the docs for HtmlPrintDocumentSource don't state that explicitly.
+        // See e.g. https://docs.microsoft.com/en-us/uwp/api/windows.ui.webui.htmlprintdocumentsource.bottommargin
+        // (and ditto for top, left, and right margins). Note that the docs for a separate class
+        // System.Drawing.Printing.Margins used elsewhere in the UWP printing API DO state that
+        // the expected units are hundredths of an inch. See e.g.
+        // https://docs.microsoft.com/en-us/dotnet/api/system.drawing.printing.margins.bottom
+        // (and ditto for top, left, and right margins).
+        source.topMargin = convertToInches(margin.top) * 100;
+        source.bottomMargin = convertToInches(margin.bottom) * 100;
+        source.leftMargin = convertToInches(margin.left) * 100;
+        source.rightMargin = convertToInches(margin.right) * 100;
+    }
+
+    if (typeof config.percentScale === 'number') {
+        source.percentScale = config.percentScale;
+    }
+}
+
+var PT = /^(.*)pt$/i,
+    IN = /^(.*)in$/i,
+    CM = /^(.*)cm$/i,
+    MM = /^(.*)mm$/i;
+
+var IN_PER_PT = 1 / 72,
+    IN_PER_CM = 1 / 2.54,
+    IN_PER_MM = 1 / 25.4;
+
+function convertToInches(unit) {
+    // Cf src/ios/APPPrinterUnit.m, but w/ inches rather than points as the target, for easier
+    // interop w/ UWP printing APIs.
+
+    if (unit === undefined || unit === null) {
+        return 0;
+    } else if (typeof unit === 'number') {
+        // If not otherwise specified, assume pt, as stated in our README
+        return unit * IN_PER_PT;
+    } else {
+        unit = '' + unit;
+        var match;
+
+        match = unit.match(PT);
+        if (match) {
+            return numberify(match[1], unit) * IN_PER_PT;
+        }
+
+        match = unit.match(IN);
+        if (match) {
+            return numberify(match[1], unit);
+        }
+
+        match = unit.match(CM);
+        if (match) {
+            return numberify(match[1], unit) * IN_PER_CM;
+        }
+
+        match = unit.match(MM);
+        if (match) {
+            return numberify(match[1], unit) * IN_PER_MM;
+        }
+
+        // If not otherwise specified, assume pt, as stated in our README
+        return numberify(unit, unit) * IN_PER_PT;
+    }
+}
+
+function numberify(unitless, inContext) {
+    var num = +unitless;
+    if (isNaN(num)) {
+        console.error('[cordova-plugin-printer] unparseable Unit string: ' + inContext);
+        num = 0;
+    }
+    return num;
+}
 
 PrintManager.getForCurrentView().onprinttaskrequested = exports.onPrintTaskRequested;
 


### PR DESCRIPTION
- Support specifying individual margins (top/bottom/left/right) on Windows, w/ same options for units as on iOS (pt (default), in, cm, and mm).
- Support Windows-specific `percentScale` property (0 - 100).
- Refactor support for `margin === false` on Windows to use the margin properties of `HTMLPrintDocumentSource` (the same ones this PR uses to support specifying individual margins), rather than the old method using `Printing.PrintBordering.borderless`. I couldn't observe the old method to have any effect.